### PR TITLE
29 special delta calc for convert bills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,4 @@ outputs/
 # Explicitly include everything in docs directory
 !docs/
 !docs/**/*
+docs/.DS_Store

--- a/src/npa_howtopay/data/sample.yaml
+++ b/src/npa_howtopay/data/sample.yaml
@@ -9,6 +9,7 @@ gas:
   gas_generation_cost_per_therm_init: 3  # cost per therm of natural gas, in initial year of model
   num_users_init: 4.5e6  # initial number of gas users
   per_user_heating_need_therms: 400.0  # household annual heating need in therms
+  per_user_water_heating_need_therms: 100.0  # household annual water heating need in therms
   pipeline_maintenance_cost_pct: 0.022  # yearly opex as a perecent of existing ratebase value (not including npas)
   user_bill_fixed_charge: 120
   ratebase_init: 30.0e9 # intitial ratebase
@@ -22,6 +23,7 @@ electric:
   distribution_cost_per_peak_kw_increase_init: 550.0 # cost to increase grid capacity to support one additional kw of peak demand, in initial year of model
   electric_maintenance_cost_pct: 0.014 # yearly opex as a perecent of existing ratebase value (not including npas)
   electricity_generation_cost_per_kwh_init: 0.11 # cost per kwh of electricity generation (just the generation cost), in initial year of model
+  water_heater_efficiency: 3 # water heater efficiency
   hp_efficiency: 3 # hp heating efficiency
   hp_peak_kw: 4.5 # peak energy consumption of a household heat pump unit
   num_users_init: 5.5e6 # initial number of electric users
@@ -32,6 +34,7 @@ electric:
 
 shared:
   cost_inflation_rate: 0.035 # rate at which expenses grow from init value; applies to generation_costs, npa_install_costs, and grid upgrade costs
+  construction_inflation_rate: 0.035 # rate at which construction expenses grow from init value; applies to non-lpp and grid upgrade capex projects
   discount_rate: 0.029 # discount rate for converting future revenue requirements and bills into today's dollars
   npa_install_costs_init: 15.0e3 # cost of installing one npa per household, in initial year of model
   npa_lifetime: 15.0 # average lifetime of an installed npa

--- a/src/npa_howtopay/data/sample.yaml
+++ b/src/npa_howtopay/data/sample.yaml
@@ -10,6 +10,7 @@ gas:
   num_users_init: 4.5e6  # initial number of gas users
   per_user_heating_need_therms: 400.0  # household annual heating need in therms
   pipeline_maintenance_cost_pct: 0.022  # yearly opex as a perecent of existing ratebase value (not including npas)
+  user_bill_fixed_charge: 120
   ratebase_init: 30.0e9 # intitial ratebase
   ror: 0.08  # gas utility return on capital
 
@@ -26,7 +27,7 @@ electric:
   num_users_init: 5.5e6 # initial number of electric users
   per_user_electric_need_kwh: 7.0e3 # per user annual electricity need in kwh
   ratebase_init: 25.0e9 # intitial ratebase
-  user_bill_fixed_cost_pct: 0.05 # percent of revenue requirement that is split evently among households as a fixed cost
+  user_bill_fixed_charge: 240 # annual fixed charge per customer ($)
   ror: 0.09 # electric utility return on capital
 
 shared:

--- a/src/npa_howtopay/model.py
+++ b/src/npa_howtopay/model.py
@@ -126,63 +126,142 @@ def inflation_adjust_revenue_requirement(revenue_req: float, year: int, start_ye
         raise ValueError(f"Year {year} cannot be before start year {start_year}")
     return revenue_req / ((1 + discount_rate) ** (year - start_year))
 
+# Average bill per user
+def calculate_avg_bill_per_user(inflation_adjusted_revenue: float, num_users: int) -> float:
+    """Calculate the average bill per user by dividing total revenue by number of users.
 
-def calculate_bill_per_user(inflation_adjusted_revenue: float, num_users: int) -> float:
-    """Calculate per-user bill amount."""
+    Args:
+        inflation_adjusted_revenue: Total revenue adjusted for inflation
+        num_users: Total number of users to divide revenue among
+
+    Returns:
+        float: Average bill amount per user
+    """
     return inflation_adjusted_revenue / num_users
 
-
-def calculate_electric_fixed_cost_per_user( fixed_charge: float
+# Electric bills
+# Fixed charge per user
+def calculate_electric_fixed_charge_per_user( fixed_charge: float
 ) -> float:
-    """Calculate electric fixed cost per user."""
+    """Return electric fixed charge per user. Currently a user defined constant"""
     return fixed_charge
 
-
-def calculate_electric_variable_cost_per_kwh(
+# Volumetric bill per user
+def calculate_electric_variable_tariff_per_kwh(
     electric_infl_adj_revenue: float, total_electric_usage_kwh: float, fixed_charge: float, num_users: int
 ) -> float:
-    """Calculate electric variable cost per kWh."""
+    """Calculate electric variable cost per kWh.
+    
+    Args:
+        electric_infl_adj_revenue: Total electric revenue adjusted for inflation
+        total_electric_usage_kwh: Total electric usage in kWh
+        fixed_charge: Fixed charge per user
+        num_users: Number of users
+        
+    Returns:
+        float: Variable cost per kWh calculated by subtracting total fixed charges 
+              from revenue and dividing by total usage
+    """
     return  (electric_infl_adj_revenue - num_users * fixed_charge)/ total_electric_usage_kwh
 
-def calculate_gas_fixed_cost_per_user( fixed_charge: float
+def calculate_gas_fixed_charge_per_user( fixed_charge: float
 ) -> float:
-    """Calculate gas fixed cost per user."""
+    """Return gas fixed cost per user. Currently a user defined constant"""
     return fixed_charge
 
-def calculate_gas_variable_cost_per_therm(
+def calculate_gas_variable_tariff_per_therm(
     gas_infl_adj_revenue: float, total_gas_usage_therms: float, fixed_charge: float = 0.0, num_users: int = 0.0,
 ) -> float:
-    """Calculate electric variable cost per kWh."""
+    """Calculate gas variable cost per therm.
+    
+    Args:
+        gas_infl_adj_revenue: Total gas revenue adjusted for inflation
+        total_gas_usage_therms: Total gas usage in therms
+        fixed_charge: Fixed charge per user
+        num_users: Number of users
+        
+    Returns:
+        float: Variable cost per therm calculated by subtracting total fixed charges
+              from revenue and dividing by total usage
+    """
     return (gas_infl_adj_revenue - num_users * fixed_charge)/ total_gas_usage_therms
 
+def calculate_nonconverts_gas_bill_per_user( gas_fixed_charge: float, gas_variable_tariff: float, per_user_heating_need: float) -> float:
+    """Calculate gas bill per user for nonconverts.
+    
+    Args:
+        gas_fixed_charge: Fixed charge per user
+        gas_variable_tariff: Variable tariff per therm
+        per_user_heating_need: Heating need per user
+        
+    Returns:
+        float: Gas bill per user for nonconverts
+    """
+    return gas_fixed_charge + gas_variable_tariff * per_user_heating_need
 
 def calculate_converts_electric_bill_per_user(
-    electric_fixed_cost: float,
-    electric_variable_cost: float,
+    electric_fixed_charge: float,
+    electric_variable_tariff: float,
     per_user_electric_need: float,
     per_user_heating_need: float,
     hp_efficiency: float,
 ) -> float:
-    """Calculate electric bill per user for converts (includes heating)."""
-    return electric_fixed_cost + electric_variable_cost * (
-        per_user_electric_need + per_user_heating_need * KWH_PER_THERM / hp_efficiency
-    )
+    """Calculate electric bill per user for converts (includes heating).
+    
+    Args:
+        electric_fixed_charge: Fixed charge per user
+        electric_variable_tariff: Variable tariff per kWh
+        per_user_electric_need: Electric need per user
+        per_user_heating_need: Heating need per user
+        hp_efficiency: Heat pump efficiency
+        
+    Returns:
+        float: Electric bill per user for converts
+    """
+    return electric_fixed_charge + electric_variable_tariff * (
+        per_user_electric_need + per_user_heating_need * KWH_PER_THERM / hp_efficiency)
+    
 
 
 def calculate_nonconverts_electric_bill_per_user(
-    electric_fixed_cost: float, electric_variable_cost: float, per_user_electric_need: float
+    electric_fixed_charge: float, electric_variable_tariff: float, per_user_electric_need: float
 ) -> float:
-    """Calculate electric bill per user for nonconverts (no heating)."""
-    return electric_fixed_cost + electric_variable_cost * per_user_electric_need
+    """Calculate electric bill per user for nonconverts (no heating).
+    
+    Args:
+        electric_fixed_charge: Fixed charge per user
+        electric_variable_tariff: Variable tariff per kWh
+        per_user_electric_need: Electric need per user
+        
+    Returns:
+        float: Electric bill per user for nonconverts
+    """
+    return electric_fixed_charge + electric_variable_tariff * per_user_electric_need
 
-
+# Total Energy bills 
 def calculate_converts_total_bill_per_user(converts_gas_bill: float, converts_electric_bill: float) -> float:
-    """Calculate total bill per user for converts (gas + electric)."""
+    """Calculate total bill per user for converts (gas + electric).
+    
+    Args:
+        converts_gas_bill: Gas bill per user for converts
+        converts_electric_bill: Electric bill per user for converts
+        
+    Returns:
+        float: Total bill per user for converts
+    """
     return converts_gas_bill + converts_electric_bill
 
 
 def calculate_nonconverts_total_bill_per_user(nonconverts_gas_bill: float, nonconverts_electric_bill: float) -> float:
-    """Calculate total bill per user for nonconverts (gas + electric)."""
+    """Calculate total bill per user for nonconverts (gas + electric).
+    
+    Args:
+        nonconverts_gas_bill: Gas bill per user for nonconverts
+        nonconverts_electric_bill: Electric bill per user for nonconverts
+        
+    Returns:
+        float: Total bill per user for nonconverts
+    """
     return nonconverts_gas_bill + nonconverts_electric_bill
 
 
@@ -213,73 +292,66 @@ def compute_bill_costs(
         (pl.col("gas_revenue_requirement") + pl.col("electric_revenue_requirement")).alias("total_revenue_requirement"),
     ])
 
-    # Create per-user gas bill columns and total inflation adjusted revenue requirement
+    #Create gas and electric tariffs columns (and total inflation adjusted revenue requirement)
     df = df.with_columns([
         (
             pl.col("gas_inflation_adjusted_revenue_requirement")
             + pl.col("electric_inflation_adjusted_revenue_requirement")
-        ).alias("total_inflation_adjusted_revenue_requirement"),
-        pl.struct(["gas_inflation_adjusted_revenue_requirement", "gas_num_users"])
+        ).alias("total_inflation_adjusted_revenue_requirement"), 
+        pl.struct(["gas_inflation_adjusted_revenue_requirement", "total_gas_usage_therms"])
         .map_elements(
-            lambda x: calculate_bill_per_user(x["gas_inflation_adjusted_revenue_requirement"], x["gas_num_users"]),
+            lambda x: calculate_gas_variable_tariff_per_therm(x["gas_inflation_adjusted_revenue_requirement"], x["total_gas_usage_therms"], input_params.gas.user_bill_fixed_charge, input_params.gas.num_users_init),
             return_dtype=pl.Float64,
         )
-        .alias("gas_bill_per_user"),
+        .alias("gas_variable_tariff_per_therm"),
+        pl.struct(["electric_inflation_adjusted_revenue_requirement", "total_electric_usage_kwh"])
+        .map_elements(
+            lambda x: calculate_electric_variable_tariff_per_kwh(x["electric_inflation_adjusted_revenue_requirement"], x["total_electric_usage_kwh"], input_params.electric.user_bill_fixed_charge, input_params.electric.num_users_init),
+            return_dtype=pl.Float64,
+        )
+        .alias("electric_variable_tariff_per_kwh"),
+        pl.lit(calculate_electric_fixed_charge_per_user(
+            input_params.electric.user_bill_fixed_charge,
+        )).alias("electric_fixed_charge_per_user"),
+        pl.lit(calculate_gas_fixed_charge_per_user(
+            input_params.gas.user_bill_fixed_charge,
+        )).alias("gas_fixed_charge_per_user"),
+    ])
+
+    # Create per-user gas bill columns and total inflation adjusted revenue requirement
+    df = df.with_columns([
         pl.struct(["gas_inflation_adjusted_revenue_requirement", "gas_num_users"])
         .map_elements(
-            lambda x: calculate_bill_per_user(x["gas_inflation_adjusted_revenue_requirement"], x["gas_num_users"]),
+            lambda x: calculate_avg_bill_per_user(x["gas_inflation_adjusted_revenue_requirement"], x["gas_num_users"]),
+            return_dtype=pl.Float64,
+        )
+        .alias("gas_avg_bill_per_user"),
+        pl.struct(["gas_inflation_adjusted_revenue_requirement", "gas_num_users"])
+        .map_elements(
+            lambda x: calculate_nonconverts_gas_bill_per_user(
+                x["gas_fixed_charge_per_user"], x["gas_variable_tariff_per_therm"], input_params.gas.per_user_heating_need_therms),
             return_dtype=pl.Float64,
         )
         .alias("gas_nonconverts_bill_per_user"),
-        pl.lit(0.0).alias("gas_converts_bill_per_user"),
-        pl.struct(["gas_inflation_adjusted_revenue_requirement", "total_gas_usage_therms"])
-        .map_elements(
-            lambda x: calculate_gas_variable_cost_per_therm(
-                x["gas_inflation_adjusted_revenue_requirement"], x["total_gas_usage_therms"], input_params.gas.user_bill_fixed_charge, input_params.gas.num_users_init
-            ),
-            return_dtype=pl.Float64,
-        )
-        .alias("gas_variable_cost_per_therm"),
+        pl.lit(0.0).alias("gas_converts_bill_per_user")
     ])
 
-    # Create electric cost calculations
-    df = df.with_columns([
-        pl.struct(["electric_inflation_adjusted_revenue_requirement", "electric_num_users"])
-        .map_elements(
-            lambda x: calculate_electric_fixed_cost_per_user(
-                input_params.electric.user_bill_fixed_charge,
-            ),
-            return_dtype=pl.Float64,
-        )
-        .alias("electric_fixed_cost_per_user"),
-        pl.struct(["electric_inflation_adjusted_revenue_requirement", "total_electric_usage_kwh"])
-        .map_elements(
-            lambda x: calculate_electric_variable_cost_per_kwh(
-                x["electric_inflation_adjusted_revenue_requirement"],
-                x["total_electric_usage_kwh"],
-                input_params.electric.user_bill_fixed_charge,
-                input_params.electric.num_users_init,
-            ),
-            return_dtype=pl.Float64,
-        )
-        .alias("electric_variable_cost_per_kwh"),
-    ])
 
     # Create converts and nonconverts electric bills
     df = df.with_columns([
         pl.struct(["electric_inflation_adjusted_revenue_requirement", "electric_num_users"])
         .map_elements(
-            lambda x: calculate_bill_per_user(
+            lambda x: calculate_avg_bill_per_user(
                 x["electric_inflation_adjusted_revenue_requirement"], x["electric_num_users"]
             ),
             return_dtype=pl.Float64,
         )
-        .alias("electric_bill_per_user"),
-        pl.struct(["electric_fixed_cost_per_user", "electric_variable_cost_per_kwh"])
+        .alias("electric_avg_bill_per_user"),
+        pl.struct(["electric_fixed_charge_per_user", "electric_variable_tariff_per_kwh"])
         .map_elements(
             lambda x: calculate_converts_electric_bill_per_user(
-                x["electric_fixed_cost_per_user"],
-                x["electric_variable_cost_per_kwh"],
+                x["electric_fixed_charge_per_user"],
+                x["electric_variable_tariff_per_kwh"],
                 input_params.electric.per_user_electric_need_kwh,
                 input_params.gas.per_user_heating_need_therms,
                 input_params.electric.hp_efficiency,
@@ -287,11 +359,11 @@ def compute_bill_costs(
             return_dtype=pl.Float64,
         )
         .alias("electric_converts_bill_per_user"),
-        pl.struct(["electric_fixed_cost_per_user", "electric_variable_cost_per_kwh"])
+        pl.struct(["electric_fixed_charge_per_user", "electric_variable_tariff_per_kwh"])
         .map_elements(
             lambda x: calculate_nonconverts_electric_bill_per_user(
-                x["electric_fixed_cost_per_user"],
-                x["electric_variable_cost_per_kwh"],
+                x["electric_fixed_charge_per_user"],
+                x["electric_variable_tariff_per_kwh"],
                 input_params.electric.per_user_electric_need_kwh,
             ),
             return_dtype=pl.Float64,
@@ -299,7 +371,7 @@ def compute_bill_costs(
         .alias("electric_nonconverts_bill_per_user"),
     ])
 
-    # Create total bill calculations
+    # Create total bill calculations for converts and nonconverts
     df = df.with_columns([
         pl.struct(["gas_converts_bill_per_user", "electric_converts_bill_per_user"])
         .map_elements(

--- a/src/npa_howtopay/params.py
+++ b/src/npa_howtopay/params.py
@@ -23,8 +23,8 @@ COMPARE_COLS = [
     "electric_nonconverts_bill_per_user",
     "electric_converts_bill_per_user",
     # volumetric rate
-    "gas_variable_cost_per_therm",
-    "electric_variable_cost_per_kwh",
+    "gas_variable_tariff_per_therm",
+    "electric_variable_tariff_per_kwh",
     # ratebase
     "gas_ratebase",
     "electric_ratebase",
@@ -66,7 +66,7 @@ class ElectricParams:
     distribution_cost_per_peak_kw_increase_init: float
     electric_maintenance_cost_pct: float
     electricity_generation_cost_per_kwh_init: float
-    user_bill_fixed_charge: float 
+    user_bill_fixed_charge: float
     grid_upgrade_depreciation_lifetime: int
     hp_efficiency: float
     hp_peak_kw: float

--- a/src/npa_howtopay/params.py
+++ b/src/npa_howtopay/params.py
@@ -46,6 +46,7 @@ class GasParams:
     gas_generation_cost_per_therm_init: float
     num_users_init: int
     per_user_heating_need_therms: float
+    per_user_water_heating_need_therms: float
     pipeline_maintenance_cost_pct: float
     ratebase_init: float
     ror: float
@@ -68,6 +69,7 @@ class ElectricParams:
     electricity_generation_cost_per_kwh_init: float
     user_bill_fixed_charge: float
     grid_upgrade_depreciation_lifetime: int
+    water_heater_efficiency: float
     hp_efficiency: float
     hp_peak_kw: float
     num_users_init: int
@@ -92,6 +94,7 @@ class ElectricParams:
 @define
 class SharedParams:
     cost_inflation_rate: float
+    construction_inflation_rate: float
     discount_rate: float
     npa_install_costs_init: float
     npa_lifetime: float

--- a/src/npa_howtopay/params.py
+++ b/src/npa_howtopay/params.py
@@ -49,6 +49,7 @@ class GasParams:
     pipeline_maintenance_cost_pct: float
     ratebase_init: float
     ror: float
+    user_bill_fixed_charge: float
     # passed down from SharedParams
     start_year: int = field(init=False)
     cost_inflation_rate: float = field(init=False)
@@ -65,7 +66,7 @@ class ElectricParams:
     distribution_cost_per_peak_kw_increase_init: float
     electric_maintenance_cost_pct: float
     electricity_generation_cost_per_kwh_init: float
-    user_bill_fixed_cost_pct: float = field(validator=validators.and_(validators.ge(0.0), validators.le(1.0)))
+    user_bill_fixed_charge: float 
     grid_upgrade_depreciation_lifetime: int
     hp_efficiency: float
     hp_peak_kw: float

--- a/src/npa_howtopay/utils.py
+++ b/src/npa_howtopay/utils.py
@@ -136,7 +136,7 @@ def plot_volumetric_tariff(
     """Volumetric Tariff - Faceted"""
     plot_utility_metric(
         plt_df=plt_df,
-        column="variable_cost",
+        column="variable_tariff",
         title="Volumetric Tariff",
         y_label_unit="$/unit",
         show_absolute=show_absolute,
@@ -290,7 +290,18 @@ def plot_total_bills(
 
 
 def transform_to_long_format(delta_bau_df: pl.DataFrame) -> pl.DataFrame:
-    """Transform wide format (gas_/electric_ prefixes) to long format with utility_type column"""
+    """Transform wide format DataFrame to long format with utility_type column.
+
+    Takes a DataFrame with gas_ and electric_ prefixed columns and transforms it into long format
+    by separating gas and electric metrics into separate rows with a utility_type column.
+    Special handling is done for variable tariff columns to standardize their names.
+
+    Args:
+        delta_bau_df (pl.DataFrame): Input DataFrame in wide format with gas_/electric_ prefixed columns
+
+    Returns:
+        pl.DataFrame: Transformed DataFrame in long format with utility_type and scenario_id columns and standardized metric names
+    """
 
     # Get all columns except year and scenario_id
     metric_cols = [col for col in delta_bau_df.columns if col not in ["year", "scenario_id"]]
@@ -307,18 +318,18 @@ def transform_to_long_format(delta_bau_df: pl.DataFrame) -> pl.DataFrame:
     gas_rename_map = {}
     for col in gas_cols:
         base_col = col.replace("gas_", "")
-        # Special case: map both variable cost columns to "variable_cost"
-        if base_col == "variable_cost_per_therm":
-            gas_rename_map[col] = "variable_cost"
+        # Special case: map both variable tariff columns to "variable_tariff"
+        if base_col == "variable_tariff_per_therm":
+            gas_rename_map[col] = "variable_tariff"
         else:
             gas_rename_map[col] = base_col
 
     electric_rename_map = {}
     for col in electric_cols:
         base_col = col.replace("electric_", "")
-        # Special case: map both variable cost columns to "variable_cost"
-        if base_col == "variable_cost_per_kwh":
-            electric_rename_map[col] = "variable_cost"
+        # Special case: map both variable tariff columns to "variable_tariff"
+        if base_col == "variable_tariff_per_kwh":
+            electric_rename_map[col] = "variable_tariff"
         else:
             electric_rename_map[col] = base_col
 

--- a/src/npa_howtopay/utils.py
+++ b/src/npa_howtopay/utils.py
@@ -54,6 +54,9 @@ def plot_utility_metric(
     ax1.set_title("GAS", fontsize=14, fontweight="bold")
     gas_data = plt_df.filter(pl.col("utility_type") == "gas")
 
+    # Add horizontal line at y=0
+    ax1.axhline(y=0, color="#333333", linestyle="-", alpha=0.5)
+
     for i, scenario in enumerate(gas_data["scenario_id"].unique()):
         color = scenario_colors.get(scenario, "#666666")
         linestyle = scenario_line_styles.get(scenario, "solid")
@@ -75,6 +78,9 @@ def plot_utility_metric(
     # Electric facet
     ax2.set_title("ELECTRIC", fontsize=14, fontweight="bold")
     electric_data = plt_df.filter(pl.col("utility_type") == "electric")
+
+    # Add horizontal line at y=0
+    ax2.axhline(y=0, color="#333333", linestyle="-", alpha=0.5)
 
     for i, scenario in enumerate(electric_data["scenario_id"].unique()):
         color = scenario_colors.get(scenario, "#666666")

--- a/tests/test_capex_project.py
+++ b/tests/test_capex_project.py
@@ -31,6 +31,7 @@ def test_get_synthetic_initial_capex_projects():
         "project_type": ["synthetic_initial", "synthetic_initial", "synthetic_initial"],
         "original_cost": [3000, 3000, 3000],
         "depreciation_lifetime": [3, 3, 3],
+        "retirement_year": [2026, 2027, 2028],
     })
     assert_frame_equal(ref_df, df, check_dtypes=False)
     assert np.isclose(compute_ratebase_from_capex_projects(start_year, df), initial_ratebase)
@@ -45,6 +46,7 @@ def test_get_non_lpp_gas_capex_projects():
         "project_type": ["misc"],
         "original_cost": [15],
         "depreciation_lifetime": [60],
+        "retirement_year": [2085],
     })
     assert_frame_equal(ref_df, df, check_dtypes=False)
 
@@ -58,6 +60,7 @@ def test_get_non_npa_electric_capex_projects():
         "project_type": ["misc"],
         "original_cost": [30],
         "depreciation_lifetime": [60],
+        "retirement_year": [2085],
     })
     assert_frame_equal(ref_df, df, check_dtypes=False)
 
@@ -118,6 +121,7 @@ def test_get_lpp_gas_capex_projects(npa_projects):
         "project_type": ["pipeline"],
         "original_cost": [23000],
         "depreciation_lifetime": [60],
+        "retirement_year": [2085],
     })
     assert_frame_equal(ref_df, df, check_dtypes=False)
 
@@ -146,6 +150,7 @@ def test_get_grid_upgrade_capex_projects(npa_projects):
         "project_type": ["grid_upgrade"],
         "original_cost": [34000],  # three projects increase peak_kw by 14, 11, 9
         "depreciation_lifetime": [30],
+        "retirement_year": [2055],
     })
     assert_frame_equal(ref_df, df, check_dtypes=False)
 
@@ -157,6 +162,7 @@ def test_get_npa_capex_projects(npa_projects):
         "project_type": ["npa"],
         "original_cost": [35000],
         "depreciation_lifetime": [10],
+        "retirement_year": [2035],
     })
     assert_frame_equal(ref_df, df, check_dtypes=False)
 
@@ -166,6 +172,7 @@ capex_df = pl.DataFrame({
     "project_year": [2025, 2026, 2027],
     "original_cost": [1000, 1000, 1000],
     "depreciation_lifetime": [10, 20, 10],
+    "retirement_year": [2035, 2045, 2035],
 })
 
 


### PR DESCRIPTION
only need to review `create_delta_bau_df()` in model.py

what changed - 
we need to handle special comparison reference points for the converts bills (total, gas, electric) 
before it was `scenario.convert_bill - bau.convert_bill `
now it is `scenario.convert_bill - bau.nonconvert_bill `